### PR TITLE
Fix file extension for mtl implementation

### DIFF
--- a/Metal-Tutorial.xcodeproj/project.pbxproj
+++ b/Metal-Tutorial.xcodeproj/project.pbxproj
@@ -14,7 +14,7 @@
 		3E581F1629871D3000E5CDF6 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E581F1529871D3000E5CDF6 /* QuartzCore.framework */; };
 		3E581F1829871D3400E5CDF6 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E581F1729871D3400E5CDF6 /* Metal.framework */; };
 		3E581F1A29871D4300E5CDF6 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E581F1929871D4300E5CDF6 /* Foundation.framework */; };
-		3E69B2312989F21B0012094B /* mtl_implementation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3E69B2302989F21B0012094B /* mtl_implementation.cpp */; };
+               3E69B2312989F21B0012094B /* mtl_implementation.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3E69B2302989F21B0012094B /* mtl_implementation.mm */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -41,7 +41,7 @@
 		3E581F1529871D3000E5CDF6 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		3E581F1729871D3400E5CDF6 /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
 		3E581F1929871D4300E5CDF6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
-		3E69B2302989F21B0012094B /* mtl_implementation.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = mtl_implementation.cpp; sourceTree = "<group>"; };
+               3E69B2302989F21B0012094B /* mtl_implementation.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = mtl_implementation.mm; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -101,7 +101,7 @@
 			isa = PBXGroup;
 			children = (
 				3E56AB66297E0E6E00DB5F4F /* main.cpp */,
-				3E69B2302989F21B0012094B /* mtl_implementation.cpp */,
+                               3E69B2302989F21B0012094B /* mtl_implementation.mm */,
 			);
 			path = "Metal-Tutorial";
 			sourceTree = "<group>";
@@ -177,7 +177,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3E56AB67297E0E6E00DB5F4F /* main.cpp in Sources */,
-				3E69B2312989F21B0012094B /* mtl_implementation.cpp in Sources */,
+                               3E69B2312989F21B0012094B /* mtl_implementation.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Metal-Tutorial/mtl_implementation.mm
+++ b/Metal-Tutorial/mtl_implementation.mm
@@ -1,5 +1,5 @@
 //
-//  mtl_implementation.cpp
+//  mtl_implementation.mm
 //  Metal-Guide
 //
 


### PR DESCRIPTION
## Summary
- rename `mtl_implementation.cpp` to `mtl_implementation.mm`
- update Xcode project to use Objective‑C++ source file

## Testing
- `curl -L -s https://api.github.com/repos/wmarti/MetalTutorial/issues | head -n 30`


------
https://chatgpt.com/codex/tasks/task_e_6844b9eed77c832ebb324c61f3b5b649